### PR TITLE
Fix for adding plex permissions

### DIFF
--- a/container_configs.py
+++ b/container_configs.py
@@ -22,7 +22,7 @@ class ContainerConfig:
             '    container_name: plex\n'
             '    network_mode: host\n'
             '    environment:\n'
-            '      - PUID=${UID}\n'
+            '      - PUID=13010n'
             '      - PGID=13000\n'
             '      - VERSION=docker\n'
             '      - PLEX_CLAIM=' + self.plex_claim + '\n'

--- a/container_configs.py
+++ b/container_configs.py
@@ -22,7 +22,7 @@ class ContainerConfig:
             '    container_name: plex\n'
             '    network_mode: host\n'
             '    environment:\n'
-            '      - PUID=13010n'
+            '      - PUID=13010\n'
             '      - PGID=13000\n'
             '      - VERSION=docker\n'
             '      - PLEX_CLAIM=' + self.plex_claim + '\n'

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,7 @@ sudo useradd prowlarr -u 13006
 sudo useradd qbittorrent -u 13007
 sudo useradd jackett -u 13008
 sudo useradd overseerr -u 13009
+sudo useradd plex -u 13010
 sudo groupadd mediacenter -g 13000
 sudo usermod -a -G mediacenter sonarr
 sudo usermod -a -G mediacenter radarr
@@ -20,9 +21,10 @@ sudo usermod -a -G mediacenter prowlarr
 sudo usermod -a -G mediacenter qbittorrent
 sudo usermod -a -G mediacenter jackett
 sudo usermod -a -G mediacenter overseerr
+sudo usermod -a -G mediacenter plex
 
 # Make directories
-sudo mkdir -pv docker/{sonarr,radarr,lidarr,readarr,mylar,prowlarr,qbittorrent,jackett,audiobookshelf,overseerr}-config
+sudo mkdir -pv docker/{sonarr,radarr,lidarr,readarr,mylar,prowlarr,qbittorrent,jackett,audiobookshelf,overseerr,plex,tautulli}-config
 sudo mkdir -pv data/{torrents,media}/{tv,movies,music,books,comics,audiobooks,podcasts,audiobookshelf-metadata}
 
 # Set permissions
@@ -37,5 +39,6 @@ sudo chown -R prowlarr:mediacenter docker/prowlarr-config
 sudo chown -R qbittorrent:mediacenter docker/qbittorrent-config
 sudo chown -R jackett:mediacenter docker/jackett-config
 sudo chown -R overseerr:mediacenter docker/overseerr-config
+sudo chown -R plex:mediacenter docker/plex-config
 
 echo "UID=$(id -u)" >> .env

--- a/users_groups_setup.py
+++ b/users_groups_setup.py
@@ -93,3 +93,8 @@ class UserGroupSetup:
         self.create_config_dir('overseerr')
         os.system('sudo usermod -a -G mediacenter overseerr')
 
+    def plex(self):
+        os.system('sudo useradd plex -u 13010')
+        self.create_config_dir('plex')
+        os.system('sudo usermod -a -G mediacenter plex')
+


### PR DESCRIPTION
While using ezarr I noticed that plex didn't have correct permissions added and the config folder was missing after running the main.py. It seems this was never properly added.

Noticed the same for tautulli and jellyfin which I might address later.