### PR TITLE
Add jellyseerr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ crash*. It doesn't necessarily mean it will run well on your system ;) It featur
   of preference, and you *could* even use both, although this is probably a waste of resources.
 - [Overseerr](https://overseerr.dev/) is a show and movie request management and media discovery
    tool.
+- [Jellyseerr](https://github.com/Fallenbagel/jellyseerr) is like Overseerr, but for Jellyfin.
 
 ## Using
 ### Using the CLI

--- a/container_configs.py
+++ b/container_configs.py
@@ -230,6 +230,23 @@ class ContainerConfig:
             '      - "5055:5055"\n'
             '    restart: unless-stopped\n\n'
         )
+    
+    def jellyseerr(self):
+        return (
+            '  jellyseerr:\n'
+            '    image: fallenbagel/jellyseerr:latest\n'
+            '    container_name: jellyseerr\n'
+            '    environment:\n'
+            '      - PUID=13012\n'
+            '      - PGID=13000\n'
+            '      - UMASK=002\n'
+            '      - TZ=' + self.timezone + '\n'
+            '    volumes:\n'
+            '      - ' + self.config_dir + '/jellyseerr-config:/app/config\n'
+            '    ports:\n'
+            '      - "5056:5055"\n'
+            '    restart: unless-stopped\n\n'
+        )
 
     def sabnzbd(self):
         return (

--- a/main.py
+++ b/main.py
@@ -74,6 +74,10 @@ if services_classed['ms'].__contains__('plex'):
         take_input('overseerr', 'servarr')
 print('Use Jellyfin? [Y/n]', end=" ")
 take_input('jellyfin', 'ms')
+if (services_classed['ms'].__contains__('jellyfin')
+        and (services_classed['servarr'].__contains__('sonarr') or services_classed['servarr'].__contains__('radarr'))):
+    print('Use Jellyseerr? [Y/n]', end=" ")
+    take_input('jellyseerr', 'servarr')
 if len(services_classed['ms']) == 0:
     print('Warning: no media servers selected.')
 

--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,7 @@ sudo useradd jackett -u 13008
 sudo useradd overseerr -u 13009
 sudo useradd plex -u 13010
 sudo useradd sabnzbd -u 13011
+sudo useradd jellyseerr -u 13012
 sudo groupadd mediacenter -g 13000
 sudo usermod -a -G mediacenter sonarr
 sudo usermod -a -G mediacenter radarr
@@ -24,9 +25,10 @@ sudo usermod -a -G mediacenter jackett
 sudo usermod -a -G mediacenter overseerr
 sudo usermod -a -G mediacenter plex
 sudo usermod -a -G mediacenter sabnzbd
+sudo usermod -a -G mediacenter jellyseerr
 
 # Make directories
-sudo mkdir -pv docker/{sonarr,radarr,lidarr,readarr,mylar,prowlarr,qbittorrent,jackett,audiobookshelf,overseerr,plex,tautulli,sabnzbd}-config
+sudo mkdir -pv docker/{sonarr,radarr,lidarr,readarr,mylar,prowlarr,qbittorrent,jackett,audiobookshelf,overseerr,plex,tautulli,sabnzbd,jellyseerr}-config
 sudo mkdir -pv data/{torrents,usenet,media}/{tv,movies,music,books,comics,audiobooks,podcasts,audiobookshelf-metadata}
 
 # Set permissions
@@ -43,5 +45,6 @@ sudo chown -R jackett:mediacenter docker/jackett-config
 sudo chown -R overseerr:mediacenter docker/overseerr-config
 sudo chown -R plex:mediacenter docker/plex-config
 sudo chown -R sabnzbd:mediacenter docker/sabnzbd-config
+sudo chown -R jellyseerr:mediacenter docker/jellyseerr-config
 
 echo "UID=$(id -u)" >> .env

--- a/users_groups_setup.py
+++ b/users_groups_setup.py
@@ -102,3 +102,8 @@ class UserGroupSetup:
         os.system('sudo useradd sabnzbd -u 13011')
         self.create_config_dir('sabnzbd')
         os.system('sudo usermod -a -G mediacenter sabnzbd')
+
+    def jellyseerr(self):
+        os.system('sudo useradd jellyseerr -u 13012')
+        self.create_config_dir('jellyseerr')
+        os.system('sudo usermod -a -G mediacenter jellyseerr')


### PR DESCRIPTION
Adds support for Jellyseerr #17 
The code is based on the earlier introduced Overseer support #24 

Edit: closes #17 
(^this is text that lets GitHub recognize #17 should be closed if this is merged)