### PR TITLE
Update setup.sh to match docker-compose.yml

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -28,23 +28,23 @@ sudo usermod -a -G mediacenter sabnzbd
 sudo usermod -a -G mediacenter jellyseerr
 
 # Make directories
-sudo mkdir -pv docker/{sonarr,radarr,lidarr,readarr,mylar,prowlarr,qbittorrent,jackett,audiobookshelf,overseerr,plex,tautulli,sabnzbd,jellyseerr}-config
+sudo mkdir -pv config/{sonarr,radarr,lidarr,readarr,mylar,prowlarr,qbittorrent,jackett,audiobookshelf,overseerr,plex,tautulli,sabnzbd,jellyseerr}-config
 sudo mkdir -pv data/{torrents,usenet,media}/{tv,movies,music,books,comics,audiobooks,podcasts,audiobookshelf-metadata}
 
 # Set permissions
 sudo chmod -R 775 data/
 sudo chown -R $(id -u):mediacenter data/
-sudo chown -R sonarr:mediacenter docker/sonarr-config
-sudo chown -R radarr:mediacenter docker/radarr-config
-sudo chown -R lidarr:mediacenter docker/lidarr-config
-sudo chown -R readarr:mediacenter docker/readarr-config
-sudo chown -R mylar:mediacenter docker/mylar-config
-sudo chown -R prowlarr:mediacenter docker/prowlarr-config
-sudo chown -R qbittorrent:mediacenter docker/qbittorrent-config
-sudo chown -R jackett:mediacenter docker/jackett-config
-sudo chown -R overseerr:mediacenter docker/overseerr-config
-sudo chown -R plex:mediacenter docker/plex-config
-sudo chown -R sabnzbd:mediacenter docker/sabnzbd-config
-sudo chown -R jellyseerr:mediacenter docker/jellyseerr-config
+sudo chown -R sonarr:mediacenter config/sonarr-config
+sudo chown -R radarr:mediacenter config/radarr-config
+sudo chown -R lidarr:mediacenter config/lidarr-config
+sudo chown -R readarr:mediacenter config/readarr-config
+sudo chown -R mylar:mediacenter config/mylar-config
+sudo chown -R prowlarr:mediacenter config/prowlarr-config
+sudo chown -R qbittorrent:mediacenter config/qbittorrent-config
+sudo chown -R jackett:mediacenter config/jackett-config
+sudo chown -R overseerr:mediacenter config/overseerr-config
+sudo chown -R plex:mediacenter config/plex-config
+sudo chown -R sabnzbd:mediacenter config/sabnzbd-config
+sudo chown -R jellyseerr:mediacenter config/jellyseerr-config
 
 echo "UID=$(id -u)" >> .env

--- a/users_groups_setup.py
+++ b/users_groups_setup.py
@@ -8,9 +8,9 @@ class UserGroupSetup:
 
     def create_config_dir(self, service_name):
         os.system(
-            f'sudo mkdir -p {self.root_dir}/docker/{service_name}-config'
-            f' ; sudo chown -R {service_name}:mediacenter {self.root_dir}/docker/{service_name}-config'
-            f' ; sudo chown $(id -u):mediacenter {self.root_dir}/docker'
+            f'sudo mkdir -p {self.root_dir}/config/{service_name}-config'
+            f' ; sudo chown -R {service_name}:mediacenter {self.root_dir}/config/{service_name}-config'
+            f' ; sudo chown $(id -u):mediacenter {self.root_dir}/config'
         )
 
     def sonarr(self):


### PR DESCRIPTION
setup.sh and docker-compose.yml use mismatched config folders.

docker-compose.yml is set up to use /data/config to configs and persistent volumes for containers while setup.sh creates /data/docker for that purpose. Docker will simply auto-create the missing /config when run or the first time but it will still work*, while the entire /docker folder structure will be left empty and useless.

The caveat is that necessary permissions won't be applied when autocreating the /config folder. setup.sh usually takes care of this but since docker isn't using that folder it's going to run with autocreated permissions, owned by root. This is not a problem on its own but there are use cases when this breaks.  On NFS filesystems without no_root_squash, the root user is basically useless, so if this script is installed on an NFS share (which is very common in virtualized environments), the containers will fail due to permission issues.

This is easily solvable by modifying either docker-compose.yml to use /docker instead of /config, or modifying setup.sh to use /config instead of /docker, which is the solution I proposed here, for no reason other than /config being a much nicer and more representative name for whats stored inside, plus it's often used in guides.

edit: I realized container_configs.py also needed to be edited, which is taken care of in my 2nd commit