### PR TITLE
fix the volume for sabnzbd

### DIFF
--- a/container_configs.py
+++ b/container_configs.py
@@ -280,7 +280,7 @@ class ContainerConfig:
             '      - TZ=' + self.timezone + '\n'
             '    volumes:\n'
             '      - ' + self.config_dir + '/sabnzbd-config:/config\n'
-            '      - ' + self.usenet_dir + ':/downloads\n'
+            '      - ' + self.usenet_dir + ':/data/usenet\n'
             '    ports:\n'
             '      - "8081:8080"\n'
             '    restart: unless-stopped\n\n'

--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -245,7 +245,7 @@ services:
       - TZ=${TIMEZONE}
     volumes:
       - ${ROOT_DIR}/config/sabnzbd-config:/config
-      - ${ROOT_DIR}/data/usenet:/downloads
+      - ${ROOT_DIR}/data/usenet:/data/usenet
     ports:
       - "8081:8080"
     restart: unless-stopped


### PR DESCRIPTION
Thank you for this work. I recently installed this, but the sabnzbd configuration didn't work with the *arrs until I changed in my generated docker compose to what I'm doing in this PR. It was unable to find the downloaded media, and I had to manually move things instead. With this fix, it works as intended and the *arrs can find and move things themselves. This also makes sabnzbd configuration consistent to how qbittorrent is set up.

Inconsistency between the docker compose and container configs was introduced in [this commit](https://github.com/Luctia/ezarr/commit/64b8b73c7aa66fc095b7a584c4fd65e61d3859d6). In the latest commit it was made consistent to `/downloads` in [docker compose](https://github.com/Luctia/ezarr/commit/1e8220bf308c5c7f59f9a933fe02244261fbf1b9#diff-7d6b10dbfcfdf480b03cd8c32f5bbd1d4d415143032fa31c80a6672082636059R248), but it doesn't work with well with the *arrs with the `/downloads` volume. Seems to work find mounting `/data/usenet`.