### PR TITLE
Feature/replace_overseerr_and_jellyseerr_with_seerr

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,9 +27,11 @@ PROWLARR_UID=13006
 QBITTORRENT_UID=13007
 JACKETT_UID=13008
 PLEX_UID=13010
-OVERSEERR_UID=13009
+# Seerr does not recommend using a non-default UID and GID.
+# See references in setup.sh or docker-compose.yml.sample.
+# SEERR_UID=13009
 SABNZBD_UID=13011
-JELLYSEERR_UID=13012
 
 # The user used to run docker-compose. To find this run: id -u
-UID=1000 
+UID=1000
+GID=1000

--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -89,32 +89,21 @@ services:
       - "6767:6767"
     restart: unless-stopped
 
-  overseerr:
-    image: sctx/overseerr:latest
-    container_name: overseerr
+  seerr:
+    image: ghcr.io/seerr-team/seerr:latest
+    init: true
+    container_name: seerr
     environment:
-      - PUID=${OVERSEERR_UID}
-      - PGID=${MEDIACENTER_GID}
-      - UMASK=002
+      # Seerr does not recommend using non-default UID/GID.
+      # See the migration documentation and GitHub Issue:
+      # https://docs.seerr.dev/migration-guide/?kubernetes-values=old#config-folder-permissions
+      # https://github.com/seerr-team/seerr/discussions/2455
       - TZ=${TIMEZONE}
+      - LOG_LEVEL=debug
     volumes:
-      - ${ROOT_DIR}/config/overseerr-config:/app/config
+      - ${ROOT_DIR}/config/seerr-config:/app/config
     ports:
       - "5055:5055"
-    restart: unless-stopped
-
-  jellyseerr:
-    image: fallenbagel/jellyseerr:latest
-    container_name: jellyseerr
-    environment:
-      - PUID=${JELLYSEERR_UID}
-      - PGID=${MEDIACENTER_GID}
-      - UMASK=002
-      - TZ=${TIMEZONE}
-    volumes:
-      - ${ROOT_DIR}/config/jellyseerr-config:/app/config
-    ports:
-      - "5056:5055"
     restart: unless-stopped
 
   prowlarr:

--- a/remove_old_users.sh
+++ b/remove_old_users.sh
@@ -17,7 +17,6 @@ sudo userdel jackett
 sudo userdel plex
 sudo userdel overseerr
 sudo userdel jellyseerr
-sudo userdel seerr
 sudo userdel qbittorrent
 sudo userdel sabnzbd
 sudo groupdel mediacenter

--- a/remove_old_users.sh
+++ b/remove_old_users.sh
@@ -17,6 +17,7 @@ sudo userdel jackett
 sudo userdel plex
 sudo userdel overseerr
 sudo userdel jellyseerr
+sudo userdel seerr
 sudo userdel qbittorrent
 sudo userdel sabnzbd
 sudo groupdel mediacenter

--- a/setup.sh
+++ b/setup.sh
@@ -17,10 +17,8 @@ sudo useradd mylar -u $MYLAR_UID
 sudo useradd prowlarr -u $PROWLARR_UID
 sudo useradd qbittorrent -u $QBITTORRENT_UID
 sudo useradd jackett -u $JACKETT_UID
-sudo useradd overseerr -u $OVERSEERR_UID
 sudo useradd plex -u $PLEX_UID
 sudo useradd sabnzbd -u $SABNZBD_UID
-sudo useradd jellyseerr -u $JELLYSEERR_UID
 sudo useradd bazarr -u $BAZARR_UID
 sudo useradd audiobookshelf -u $AUDIOBOOKSHELF_UID
 sudo groupadd mediacenter -g $MEDIACENTER_GID
@@ -39,16 +37,14 @@ sudo usermod -a -G mediacenter mylar
 sudo usermod -a -G mediacenter prowlarr
 sudo usermod -a -G mediacenter qbittorrent
 sudo usermod -a -G mediacenter jackett
-sudo usermod -a -G mediacenter overseerr
 sudo usermod -a -G mediacenter plex
 sudo usermod -a -G mediacenter sabnzbd
-sudo usermod -a -G mediacenter jellyseerr
 sudo usermod -a -G mediacenter bazarr
 sudo usermod -a -G mediacenter audiobookshelf
 
 # Make directories
 # ${ROOT_DIR:-.}/ means take the value from ROOT_DIR value, if failed or empty place it in the current folder
-sudo mkdir -pv ${ROOT_DIR:-.}/config/{sonarr,radarr,lidarr,mylar,prowlarr,qbittorrent,jackett,audiobookshelf,overseerr,plex,jellyfin,tautulli,sabnzbd,jellyseerr,bazarr}-config
+sudo mkdir -pv ${ROOT_DIR:-.}/config/{sonarr,radarr,lidarr,mylar,prowlarr,qbittorrent,jackett,audiobookshelf,seerr,plex,jellyfin,tautulli,sabnzbd,bazarr}-config
 sudo mkdir -pv ${ROOT_DIR:-.}/data/{torrents,usenet,media}/{tv,movies,music,books,comics,audiobooks,podcasts,audiobookshelf-metadata}
 
 # Set permissions
@@ -63,12 +59,14 @@ sudo chown -R mylar:mediacenter ${ROOT_DIR:-.}/config/mylar-config
 sudo chown -R prowlarr:mediacenter ${ROOT_DIR:-.}/config/prowlarr-config
 sudo chown -R qbittorrent:mediacenter ${ROOT_DIR:-.}/config/qbittorrent-config
 sudo chown -R jackett:mediacenter ${ROOT_DIR:-.}/config/jackett-config
-sudo chown -R overseerr:mediacenter ${ROOT_DIR:-.}/config/overseerr-config
+
+# The Seerr container uses 1000:1000
+# See https://docs.seerr.dev/migration-guide/?kubernetes-values=old#config-folder-permissions
+sudo chown -R $UID:$GID ${ROOT_DIR:-.}/config/seerr-config
 sudo chown -R plex:mediacenter ${ROOT_DIR:-.}/config/plex-config
 sudo chown -R $UID:mediacenter ${ROOT_DIR:-.}/config/jellyfin-config
 sudo chown -R $UID:mediacenter ${ROOT_DIR:-.}/config/tautulli-config
 sudo chown -R sabnzbd:mediacenter ${ROOT_DIR:-.}/config/sabnzbd-config
-sudo chown -R jellyseerr:mediacenter ${ROOT_DIR:-.}/config/jellyseerr-config
 sudo chown -R bazarr:mediacenter ${ROOT_DIR:-.}/config/bazarr-config
 sudo chown -R audiobookshelf:mediacenter ${ROOT_DIR:-.}/config/audiobookshelf-config
 


### PR DESCRIPTION
## Background
The Overseerr and Jellyseerr projects have been merged into one project now called "Seerr". This means the currently used Overseerr and Jellyseerr containers unmaintained.

## Scope
This would only replace the manual install steps with the new Seerr application. I am more well versed with shell scripts than Python so I thought that would be an easier start. From what I could tell, the python scripts do not rely on any files used in the manual installation (Correct me if I'm wrong here).

### Changes
- Based on the Seerr migration documentation, they recommend to use the container's default UID and GID. (See [link](https://docs.seerr.dev/migration-guide/?kubernetes-values=old#config-folder-permissions) and [link](https://github.com/seerr-team/seerr/discussions/2455))
- Replace all Overseerr items with Seerr
- Remove all Jellyseerr items
- I didn't remove Overseerr and Jellyseer from the `remove_old_users.sh` script since I wasn't sure if they should be kept for legacy users.